### PR TITLE
DF-3216 - Added service connection region dropdown, updated manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ The following block of code contains the required parameters that must be set:
 var application = "Application Name";
 var scanConfig = "Scan Configuration Name";
 
-// May vary depending on region
-var endpoint = "https://us.api.insight.rapid7.com/ias/v1";
+var region = "us";
 var apiKey = "your-api-key";
 
 var waitForCompletion = true;
@@ -155,9 +154,9 @@ Before configuring the build or release pipeline, we need to setup a custom serv
 
 3. Select `+ New service connection`
 
-4. Select InsightAppSec as the type
+4. Select Rapid7 InsightAppSec as the type
 
-5. Enter the connection name, endpoint URL, and API key accordingly
+5. Enter the connection name, InsightAppSec region, and API key accordingly
 
 6. Save the connection and ensure it appears in the list of service connections for that project
 

--- a/overview.md
+++ b/overview.md
@@ -52,7 +52,7 @@ Once an API key has been generated, a Service Connection in Azure DevOps used fo
 
 4. Select `Rapid7 InsightAppSec` from the dropdown
 
-5. Enter the connection name, endpoint URL, and API key accordingly
+5. Enter the connection name, InsightAppSec region, and API key accordingly
 
 6. Save the connection and ensure it appears in the list of service connections for that project
 

--- a/tasks/InsightAppSec/task.json
+++ b/tasks/InsightAppSec/task.json
@@ -11,8 +11,8 @@
         "Release"
       ],
     "version": {
-        "Major": 0,
-        "Minor": 1,
+        "Major": 1,
+        "Minor": 0,
         "Patch": 0
     },
     "instanceNameFormat": "Rapid7 InsightAppSec",

--- a/tasks/InsightAppSec/task.ts
+++ b/tasks/InsightAppSec/task.ts
@@ -18,10 +18,11 @@ async function run() {
 
         // Retrieve the connection that the user selected
         var connectedService = tl.getInput("apiConnection", true);
-        var endpoint = tl.getEndpointUrl(connectedService, true);
+        var region = tl.getEndpointDataParameter(connectedService, "region", true);
         var endpointAuth = tl.getEndpointAuthorization(connectedService, true);
+        var endpoint = "https://" + region + ".api.insight.rapid7.com/ias/v1"
         var apiKey = endpointAuth.parameters["apitoken"];
-
+        
         var scanCheckInterval = 0;
         var scanTimeout = 0;
         var vulnQuery = "";

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -4,7 +4,7 @@
     "name": "Rapid7 InsightAppSec",
     "version": "1.0.0",
     "publisher": "rapid7",
-    "public" : false,
+    "public" : true,
     "targets": [
         {
             "id": "Microsoft.VisualStudio.Services"

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1.0,
     "id": "rapid7-insightappsec-extension",
     "name": "Rapid7 InsightAppSec",
-    "version": "0.2.0",
+    "version": "1.0.0",
     "publisher": "rapid7",
     "public" : false,
     "targets": [
@@ -34,6 +34,20 @@
         "color": "rgb(236,236,236)",
         "theme": "light"
     },
+    "links": {
+        "getstarted": {
+            "uri": "https://insightappsec.help.rapid7.com/docs/azure-devops-integration"
+        },
+        "license": {
+            "uri": "https://github.com/rapid7/insightappsec-azure-devops-extension/blob/master/LICENSE.txt"
+        },
+        "support": {
+            "uri": "https://www.rapid7.com/for-customers/"
+        },
+        "issues": {
+            "uri": "https://github.com/rapid7/insightappsec-azure-devops-extension/issues"
+        }
+    },
     "icons": {
         "default": "images/rapid7.png"
     },
@@ -42,6 +56,10 @@
             "path": "tasks/InsightAppSec"
         }
     ],
+    "repository": {
+        "type": "git",
+        "uri": "https://github.com/rapid7/insightappsec-azure-devops-extension"
+    },
     "contributions": [
         {
             "id": "insightappsec-task",
@@ -64,14 +82,59 @@
               "name": "ias",
               "displayName": "Rapid7 InsightAppSec",
               "url": {
-                "displayName": "Endpoint URL",
-                "value": "https://us.api.insight.rapid7.com/ias/v1",
-                "helpText": "Url of the InsightAppSec instance to connect to for API transactions. Currently supported API endpoints per region are documented at https://insight.help.rapid7.com/docs/product-apis#section-supported-regions"
+                "displayName": "URL",
+                "value": "https://rapid7.com",
+                "required": false,
+                "isVisible": false
               },
+              "inputDescriptors": [
+                {
+                    "id": "region",
+                    "name": "Region",
+                    "description": "Your Rapid7 InsightAppSec region",
+                    "type": null,
+                    "properties": null,
+                    "inputMode": "combo",
+                    "isConfidential": false,
+                    "useInDefaultDescription": false,
+                    "groupName": null,
+                    "valueHint": null,
+                    "validation": {
+                      "dataType": "string",
+                      "isRequired": true
+                    },
+                    "values": {
+                      "inputId": "regionValues",
+                      "defaultValue": "US",
+                      "possibleValues": [
+                        {
+                          "value": "us",
+                          "displayValue": "US"
+                        },
+                        {
+                          "value": "eu",
+                          "displayValue": "EU"
+                        },
+                        {
+                            "value": "au",
+                            "displayValue": "AU"
+                        },
+                        {
+                            "value": "ca",
+                            "displayValue": "CA"
+                        },
+                        {
+                            "value": "ap",
+                            "displayValue": "AP"
+                        }
+                      ]
+                    }
+                }
+            ],
               "dataSources": [
                 {
                     "name": "Application",
-                    "endpointUrl": "{{endpoint.url}}/apps",
+                    "endpointUrl": "https://$(endpoint.region).api.insight.rapid7.com/ias/v1/apps",
                     "resultSelector": "jsonpath:$.data[*].name"
                 }
               ],


### PR DESCRIPTION
### Description
Updated the custom Rapid7 InsightAppSec service connection to have a region dropdown, replacing the previous textbox where users had to enter a URL for connecting to the API. Region selection allows for far less user error and will make extension usage easier. Currently regions are limited to the values listed, with no option for providing a custom or "other" value.

Also updated the manifest to add links and repository. Updated docs as well to account for the service connection changes.

### How Has This Been Tested?
Tested in ESCLab (since we learned we can't publish the same extension under the same publisher).