### PR TITLE
Filter scan configurations on lookup by application id in scope

### DIFF
--- a/extension.spec.yaml
+++ b/extension.spec.yaml
@@ -3,7 +3,7 @@ products: [insightappsec]
 name: insightappsec_azure_devops_extension
 title: Azure DevOps Extension
 description: Integrate InsightAppSec application security scans into Azure DevOps build and release pipelines
-version: 1.0.4
+version: 1.0.5
 vendor: rapid7
 status: []
 support: rapid7

--- a/help.md
+++ b/help.md
@@ -77,6 +77,7 @@ If the scan gating doesn't appear to occur as expected, confirm that the vulnera
 
 # Version History
 
+* 1.0.5 - Bug fix to filter Scan Configuration lookup by Application ID
 * 1.0.4 - Additional logging during Application search; add Content-Type and Accept headers on all API requests
 * 1.0.3 - Patch for vulnerability gating; improvements for build/release process
 * 1.0.0 - Initial extension

--- a/tasks/InsightAppSec/helpers/insightAppSecApi.ts
+++ b/tasks/InsightAppSec/helpers/insightAppSecApi.ts
@@ -46,14 +46,14 @@ export default class InsightAppSecApi
         }.bind(this));
     }
 
-    public async getScanConfigId(configName)
+    public async getScanConfigId(configName, applicationId)
     {
         return new Promise(async function (resolve, reject)
         {
             try
             {
                 var response;
-                var payload = {type: "SCAN_CONFIG", query: "scanconfig.name='" + configName + "'"};
+                var payload = {type: "SCAN_CONFIG", query: "scanconfig.name='" + configName + "' && scanconfig.app.id='" + applicationId + "'"};
 
                 response = await this.makeApiRequest(this.endpoint + "/search", "POST", payload);
 
@@ -293,6 +293,7 @@ export default class InsightAppSecApi
                 xhr.setRequestHeader("X-Api-Key", this.apiKey);
                 xhr.setRequestHeader("Content-Type", "application/json");
                 xhr.setRequestHeader("Accept", "application/json");
+                xhr.setRequestHeader("User-Agent", "r7:insightappsec-azure-devops-extension/1.0.5");
 
                 if (payload != null && payload != "")
                 {

--- a/tasks/InsightAppSec/task.json
+++ b/tasks/InsightAppSec/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 5
     },
     "instanceNameFormat": "Rapid7 InsightAppSec",
     "inputs": [

--- a/tasks/InsightAppSec/task.ts
+++ b/tasks/InsightAppSec/task.ts
@@ -48,7 +48,7 @@ async function run() {
         var appId = await iasApi.getAppId(application);
         console.log("Application ID for " + application + ": " + appId);
 
-        var scanConfigId = await iasApi.getScanConfigId(scanConfig);
+        var scanConfigId = await iasApi.getScanConfigId(scanConfig, appId);
         console.log("Scan Config ID for " + scanConfig + ": " + scanConfigId);
 
         // Submit a new scan

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1.0,
     "id": "rapid7-insightappsec-extension",
     "name": "Rapid7 InsightAppSec",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "publisher": "rapid7",
     "public" : true,
     "targets": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
- Add User-Agent for tracking by PA
- Restrict lookup of scanconfig by application id to avoid returning the wrong scan config by name


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


### Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
<!--- You may remove any that do not apply or add additional checks as reminders. -->
- [ ] I have updated the documentation accordingly (if changes are required).
- [ ] I have tested the changes locally.


### Miscellaneous Details:
<!--- Provide any additional details you feel are relevant. -->
