### PR TITLE
LSI-1095:

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The following steps can be used in uploading the extension to the Marketplace, a
 5. Use the command `tfx extension publish --token [token]` to package and publish the extension, replacing `[token]` with the personal access token that was previously generated
 
 ### Publishing as rapid7
-After merging a new version of the plugin to master the following actions will automatically be performed
+Any new commits merged to master will result in a build of the extension and the attempt to publish it to the extension library. It is important to ensure that a new version is defined appropriate for the changes and that the version does not collide with a previous release version. Once merged, the following actions will be automatically performed by the GitHub Actions `publish` action:
 
 1. A tag is created
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,20 @@ The following steps can be used in uploading the extension to the Marketplace, a
 
 5. Use the command `tfx extension publish --token [token]` to package and publish the extension, replacing `[token]` with the personal access token that was previously generated
 
+### Publishing as rapid7
+After merging a new version of the plugin to master the following actions will automatically be performed
+
+1. A tag is created
+
+2. A release is created
+
+3. Extension is compiled
+
+4. Extension is published to the rapid7 publisher account (public immediately)
+
+After publishing it's good practice to install the latest version of the plugin and validate functionality by running a job.
+
+
 ### Installation
 
  The following steps can be used in installing the shared extension within an organization.

--- a/extension.spec.yaml
+++ b/extension.spec.yaml
@@ -3,7 +3,7 @@ products: [insightappsec]
 name: insightappsec_azure_devops_extension
 title: Azure DevOps Extension
 description: Integrate InsightAppSec application security scans into Azure DevOps build and release pipelines
-version: 1.0.5
+version: 1.0.6
 vendor: rapid7
 status: []
 support: rapid7

--- a/help.md
+++ b/help.md
@@ -77,6 +77,7 @@ If the scan gating doesn't appear to occur as expected, confirm that the vulnera
 
 # Version History
 
+* 1.0.6 - Add basic validation to the Vulnerability Query field and additional logging if the vulnerability request fails
 * 1.0.5 - Bug fix to filter Scan Configuration lookup by Application ID
 * 1.0.4 - Additional logging during Application search; add Content-Type and Accept headers on all API requests
 * 1.0.3 - Patch for vulnerability gating; improvements for build/release process

--- a/tasks/InsightAppSec/helpers/insightAppSecApi.ts
+++ b/tasks/InsightAppSec/helpers/insightAppSecApi.ts
@@ -316,7 +316,7 @@ export default class InsightAppSecApi
                     if (xhr.status < 200 || xhr.status > 299) {
                         console.error("Failed to return valid response from InsightAppSec API; Status Code: " + xhr.status +
                             ". Please Contact Rapid7 Support if this continues to occur.");
-                        console.error(xhr.responseText);
+                        console.error("IAS Error response: " + xhr.responseText);
                         resolve(null);
                         return;
                     }

--- a/tasks/InsightAppSec/helpers/insightAppSecApi.ts
+++ b/tasks/InsightAppSec/helpers/insightAppSecApi.ts
@@ -152,8 +152,8 @@ export default class InsightAppSecApi
                     }
                     else
                     {
-                        console.log("Error retrieving scan vulnerabilities");
-                        resolve(null);
+                        console.log("Error retrieving scan vulnerabilities, check the 'Vulnerability Query' field is valid.");
+                        return reject(new Error("Request to retrieve vulnerabilities was unsuccessful."));
                     }
                     index++;
                     nextPageUrl = await this.getNextPageUrl(parsedResponse.links);
@@ -293,7 +293,7 @@ export default class InsightAppSecApi
                 xhr.setRequestHeader("X-Api-Key", this.apiKey);
                 xhr.setRequestHeader("Content-Type", "application/json");
                 xhr.setRequestHeader("Accept", "application/json");
-                xhr.setRequestHeader("User-Agent", "r7:insightappsec-azure-devops-extension/1.0.5");
+                xhr.setRequestHeader("User-Agent", "r7:insightappsec-azure-devops-extension/1.0.6");
 
                 if (payload != null && payload != "")
                 {
@@ -316,7 +316,9 @@ export default class InsightAppSecApi
                     if (xhr.status < 200 || xhr.status > 299) {
                         console.error("Failed to return valid response from InsightAppSec API; Status Code: " + xhr.status +
                             ". Please Contact Rapid7 Support if this continues to occur.");
+                        console.error(xhr.responseText);
                         resolve(null);
+                        return;
                     }
 
                     var locationHeader = xhr.getResponseHeader("Location");

--- a/tasks/InsightAppSec/package.json
+++ b/tasks/InsightAppSec/package.json
@@ -14,6 +14,6 @@
     "@types/q": "^1.0.6",
     "es6-promise": "^4.2.5",
     "ts-node": "^7.0.1",
-    "typescript": "^3.1.6"
+    "typescript": "^3.2.2"
   }
 }

--- a/tasks/InsightAppSec/task.json
+++ b/tasks/InsightAppSec/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 5
+        "Patch": 6
     },
     "instanceNameFormat": "Rapid7 InsightAppSec",
     "inputs": [
@@ -102,7 +102,11 @@
             "label": "Vulnerability Query",
             "required": false,
             "helpMarkDown": "If the scan results contain vulnerabilities that match this query, then the task will fail.",
-            "visibleRule": "hasScanGating = true"
+            "visibleRule": "hasScanGating = true",
+            "validation": {
+                "expression": "isMatch(value, '^(?!.*\").*$', 'IgnoreCase')",
+                "message": "Double quote (\") is an invalid character, use single quote (')."
+            }
         }
     ],
     "dataSourceBindings": [


### PR DESCRIPTION
- Add validation to the Vulnerability Query field that flags uses of double quote.
- Add additional logging when the vulnerability query fails.
- Ensure return on error rather than trying to continue execution.

### Description
Regex that disallows double quotes as part of the scan gating vulnerability query, additional logging and a few missed return statements.


### How Has This Been Tested?
1) Local testing
2) Testing in ADO, including the UI validation

Both sets of tests check
- Build with no scan gating
- Build with valid scan gating
- Build with invalid scan gating query


### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] I have updated the documentation accordingly (if changes are required).
- [X] I have tested the changes locally.
