### PR TITLE
Added additional check for empty/null vulnQuery if hasScanGating is true

### DIFF
--- a/tasks/InsightAppSec/task.ts
+++ b/tasks/InsightAppSec/task.ts
@@ -88,7 +88,7 @@ async function run() {
         var query = "vulnerability.scans.id='" + scanId + "'"
 
         // Check vulnerability query if one was given
-        if (hasScanGating)
+        if (hasScanGating && vulnQuery != null && vulnQuery != "")
         {
             var formattedQuery = query + "&&" + vulnQuery;
             var queryVulns = await iasApi.getScanVulns(formattedQuery);

--- a/tasks/InsightAppSec/task.ts
+++ b/tasks/InsightAppSec/task.ts
@@ -88,7 +88,7 @@ async function run() {
         var query = "vulnerability.scans.id='" + scanId + "'"
 
         // Check vulnerability query if one was given
-        if (hasScanGating && vulnQuery != null && vulnQuery != "")
+        if (hasScanGating && vulnQuery)
         {
             var formattedQuery = query + "&&" + vulnQuery;
             var queryVulns = await iasApi.getScanVulns(formattedQuery);


### PR DESCRIPTION
### Description
Add check to see if vulnQuery is null or empty before proceeding to get scan vulnerabilities


### Motivation and Context
https://issues.corp.rapid7.com/browse/DF-4073


### How Has This Been Tested?
Test case 3 here: https://wiki.corp.rapid7.com/display/EXT/ADO+v1.0.7+Test+Plan


### Types of changes
- Bug fix (non-breaking change which fixes an issue)