### PR TITLE
Fixed undefined report saving path for release pipelines

### DIFF
--- a/tasks/InsightAppSec/task.ts
+++ b/tasks/InsightAppSec/task.ts
@@ -9,16 +9,6 @@ import InsightAppSecApi from './helpers/insightAppSecApi';
 async function run() {
     try {
 
-        var hostType = process.env.SYSTEM_HOSTTYPE;
-        // Check if release or build pipeline to assign base path for report saving
-        var baseReportPath = null;
-        if (hostType != 'build'){
-            baseReportPath = process.env.SYSTEM_ARTIFACTSDIRECTORY;
-        }
-        else {
-            baseReportPath = process.env.BUILD_ARTIFACTSTAGINGDIRECTORY;
-        }
-
         // Retrieve user input
         var application = tl.getInput("application");
         var scanConfig = tl.getInput("scanConfig");
@@ -119,6 +109,7 @@ async function run() {
             var attackModules = await iasApi.getAttackModules(vulnerabilities);
 
             var metricsReport = await generateMetrics(vulnSeverities, attackModules);
+            var baseReportPath = getBaseReportPath();
             var metricsFilePath = baseReportPath + "\\" + "insightappsec-scan-metrics.json";            
             writeReport(metricsFilePath, metricsReport);
 
@@ -289,6 +280,19 @@ function writeReport(filePath, fileContent)
     {
         console.log("File already exists: " + filePath);
     }
+}
+
+function getBaseReportPath(){
+    var hostType = process.env.SYSTEM_HOSTTYPE;
+    // Check if release or build pipeline to assign base path for report saving
+    var baseReportPath = null;
+    if (hostType != "build"){
+        baseReportPath = process.env.SYSTEM_ARTIFACTSDIRECTORY;
+    }
+    else {
+        baseReportPath = process.env.BUILD_ARTIFACTSTAGINGDIRECTORY;
+    }
+    return baseReportPath;
 }
 
 run();

--- a/tasks/InsightAppSec/task.ts
+++ b/tasks/InsightAppSec/task.ts
@@ -8,6 +8,17 @@ import InsightAppSecApi from './helpers/insightAppSecApi';
 
 async function run() {
     try {
+
+        var hostType = process.env.SYSTEM_HOSTTYPE;
+        // Check if release or build pipeline to assign base path for report saving
+        var baseReportPath = null;
+        if (hostType != 'build'){
+            baseReportPath = process.env.SYSTEM_ARTIFACTSDIRECTORY;
+        }
+        else {
+            baseReportPath = process.env.BUILD_ARTIFACTSTAGINGDIRECTORY;
+        }
+
         // Retrieve user input
         var application = tl.getInput("application");
         var scanConfig = tl.getInput("scanConfig");
@@ -107,14 +118,13 @@ async function run() {
             var vulnSeverities = await iasApi.getVulnSeverities(vulnerabilities);
             var attackModules = await iasApi.getAttackModules(vulnerabilities);
 
-            var path = process.env.BUILD_ARTIFACTSTAGINGDIRECTORY;
             var metricsReport = await generateMetrics(vulnSeverities, attackModules);
-            var metricsFilePath = path + "\\" + "insightappsec-scan-metrics.json";
+            var metricsFilePath = baseReportPath + "\\" + "insightappsec-scan-metrics.json";            
             writeReport(metricsFilePath, metricsReport);
 
             if (generateFindingsReport)
             {
-                var findingsReportPath = path + "\\" + "insightappsec-scan-findings.json";
+                var findingsReportPath = baseReportPath + "\\" + "insightappsec-scan-findings.json";
                 writeReport(findingsReportPath, JSON.stringify(vulnerabilities));
             }
         }


### PR DESCRIPTION
### Description
The code now detects whether it is running in a build or a release pipeline and sets the directory path as required for saving the findings report


### Motivation and Context
https://issues.corp.rapid7.com/browse/DF-4068


### How Has This Been Tested?
Test cases 1 and 2 here: https://wiki.corp.rapid7.com/display/EXT/ADO+v1.0.7+Test+Plan


### Types of changes
- Bug fix (non-breaking change which fixes an issue)


### Checklist:
- [x] I have tested the changes locally.
