### PR TITLE
IAS-10882: Upload report if enabled before gating check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @rapid7/luxorleads

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rapid7/luxorleads

--- a/manifest.json
+++ b/manifest.json
@@ -21,8 +21,13 @@
         "sourceUrl": "https://github.com/rapid7/insightappsec-azure-devops-extension",
         "licenseUrl": "https://github.com/rapid7/insightappsec-azure-devops-extension/blob/master/LICENSE.txt"
     },
-    "version": "1.2.3",
+    "version": "1.2.4",
     "versionHistory": [
+        {
+            "version": "1.2.4",
+            "date": "",
+            "changes": "Changed logic so reports get uploaded even if gating fails."
+        },
         {
             "version": "1.2.3",
             "date": "",

--- a/tasks/InsightAppSec/helpers/insightAppSecApi.ts
+++ b/tasks/InsightAppSec/helpers/insightAppSecApi.ts
@@ -4,7 +4,7 @@ const HttpsProxyAgent = require('https-proxy-agent');
 const LOCATION_HEADER = "location";
 const CONTENT_TYPE_HEADER = "application/json";
 const ACCEPT_HEADER = "application/json";
-const USER_AGENT_HEADER = "r7:insightappsec-azure-devops-extension/1.2.3";
+const USER_AGENT_HEADER = "r7:insightappsec-azure-devops-extension/1.2.4";
 const UUID_REGEX = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/
 
 function setupProxyAgent(proxyUrl) {

--- a/tasks/InsightAppSec/task.json
+++ b/tasks/InsightAppSec/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 2,
-        "Patch": 3
+        "Patch": 4
     },
     "instanceNameFormat": "Rapid7 InsightAppSec",
     "inputs": [

--- a/tasks/InsightAppSec/task.ts
+++ b/tasks/InsightAppSec/task.ts
@@ -98,16 +98,6 @@ async function run() {
 
         var query = "vulnerability.scans.id='" + scanId + "'"
 
-        // Check vulnerability query if one was given
-        if (hasScanGating && vulnQuery) {
-            var formattedQuery = query + "&&" + vulnQuery;
-            var queryVulns = await iasApi.getScanVulns(formattedQuery);
-
-            if (queryVulns != null && queryVulns.length > 0) {
-                throw Error("Findings (" + queryVulns.length.toString() + ") were found matching the scan gating query for Scan ID " + scanId + ". Failing build.");
-            }
-        }
-
         // Continue to grab vuln and report info if scan was successful
         var vulnerabilities = await iasApi.getScanVulns(query);
 
@@ -133,6 +123,16 @@ async function run() {
                 }
                 else {
                     publishBuildPipelineArtifacts(artifacts, artifactPerReport);
+                }
+            }
+            
+            // Check vulnerability query if one was given
+            if (hasScanGating && vulnQuery) {
+                var formattedQuery = query + "&&" + vulnQuery;
+                var queryVulns = await iasApi.getScanVulns(formattedQuery);
+                
+                if (queryVulns != null && queryVulns.length > 0) {
+                    throw Error("Findings (" + queryVulns.length.toString() + ") were found matching the scan gating query for Scan ID " + scanId + ". Failing build.");
                 }
             }
         }

--- a/tasks/InsightAppSec/task.ts
+++ b/tasks/InsightAppSec/task.ts
@@ -117,6 +117,7 @@ async function run() {
                 writeReport(findingsReportPath, JSON.stringify(vulnerabilities));
                 artifacts.push(findingsReportPath)
             }
+
             if (publishPipelineArtifactsBool) {
                 if (hostType != BUILD_HOST_TYPE) {
                     publishReleasePipelineArtifacts(artifacts, baseReportPath);
@@ -125,12 +126,12 @@ async function run() {
                     publishBuildPipelineArtifacts(artifacts, artifactPerReport);
                 }
             }
-            
+
             // Check vulnerability query if one was given
             if (hasScanGating && vulnQuery) {
                 var formattedQuery = query + "&&" + vulnQuery;
                 var queryVulns = await iasApi.getScanVulns(formattedQuery);
-                
+
                 if (queryVulns != null && queryVulns.length > 0) {
                     throw Error("Findings (" + queryVulns.length.toString() + ") were found matching the scan gating query for Scan ID " + scanId + ". Failing build.");
                 }

--- a/tasks/InsightAppSec/task.ts
+++ b/tasks/InsightAppSec/task.ts
@@ -137,6 +137,10 @@ async function run() {
                 }
             }
         }
+
+        if (vulnerabilities == null && generateFindingsReport) {
+            console.log("No vulnerabilities returned from InsightAppSec to generate a report for this scan.")
+        }
     }
     catch (err) {
         tl.setResult(tl.TaskResult.Failed, err);

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1.0,
     "id": "rapid7-insightappsec-extension",
     "name": "Rapid7 InsightAppSec",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "publisher": "rapid7",
     "public": true,
     "targets": [


### PR DESCRIPTION
### Description
- Reorder the logic which checks the scan gating condition to be after the report upload, so that we do not lose the reporting generated when the build is failed due to meeting the gating condition.
-  Adding a CODEOWNERS file requiring any PR's to be approved by a luxor lead.
- Adding extra logging to explain if a report isn't generated due to 0 vulnerabiliities.

### Motivation and Context
If this integration has both;
`generateFindingsReport=true`
`hasScanGating=true`

We always checked the scan gating condition (i.e. the condition if met would fail the build) before doing any reporting logic. 

### How Has This Been Tested?
Testing completed by running this locally, against scans with and without a gating condition, with and without reporting enabled, and against scans that completed, failed, had vulns, had no vulns.

### Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
<!--- You may remove any that do not apply or add additional checks as reminders. -->
- [x] I have updated the documentation accordingly (if changes are required).
- [x] I have tested the changes locally.